### PR TITLE
Point the hyperlink on README to latest Tabjolt version

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,11 +1,10 @@
 # TabJolt #
 ### Latest Release ###
-* [Release 2022.2.2](https://github.com/tableau/tabjolt/releases/tag/v2022.2.2)
+* [Release 2022.2.2](https://github.com/tableau/tabjolt/releases/tag/v2022.2.3)
   * Please consider using the 2022.2.x release in order to ensure you are running with all available bug fixes and new features, including no log4j or Spring vulnerabilities.
   * This release includes significant documentation updates available in the `docs` folder of the package.
 
-### TabJolt Readme 
+### TabJolt Readme
 
 We encourage TabJolt users to take advantage of the documentation provided in the `docs` folder of the TabJolt package.<br>
 That documentation includes an Overview, a Quick Start Guide, and Troubleshooting and Configuration sections.
-


### PR DESCRIPTION
The `readme` file does no point to the latest Tabjolt release. It points to a previous version. This fixes it. 